### PR TITLE
Implement real logout feature

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -48,7 +48,7 @@
             <string>Editor</string>
             <key>CFBundleURLSchemes</key>
             <array>
-                <string>com.fusionauth.flutterdemo://login-callback</string>
+                <string>com.fusionauth.flutterdemo</string>
             </array>
         </dict>
     </array>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,9 +9,14 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 final FlutterAppAuth appAuth = FlutterAppAuth();
 const FlutterSecureStorage secureStorage = FlutterSecureStorage();
 
+/// For a real-world app, this should be an Internet-facing URL to FusionAuth.
+/// If you are running FusionAuth locally and just want to test the app, you can
+/// specify a local IP address (if the device is connected to the same network
+/// as the computer running FusionAuth) or even use ngrok to expose your
+/// instance to the Internet temporarily.
+const String FUSIONAUTH_DOMAIN = 'your-fusionauth-public-url';
 const String FUSIONAUTH_SCHEME = 'https';
-const String FUSIONAUTH_DOMAIN = '1a5321098cb0.ngrok.io';
-const String FUSIONAUTH_CLIENT_ID = '7e3637e8-723a-42d6-9d1d-5cb36128d6f1';
+const String FUSIONAUTH_CLIENT_ID = 'e9fdb985-9173-4e01-9d73-ac2d60d1dc8e';
 
 const String FUSIONAUTH_REDIRECT_URI =
     'com.fusionauth.flutterdemo://login-callback';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -74,18 +74,18 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_appauth
-      sha256: e2f48b18420d98b579822f1a0cac167179ca9dc3da1b0144399d0ccc7be192c8
+      sha256: a047019b525ab0e260776d1b0da1000b7416b45b9e8dd02d124c9da571fc1918
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "6.0.0"
   flutter_appauth_platform_interface:
     dependency: transitive
     description:
       name: flutter_appauth_platform_interface
-      sha256: "4f1a706990457c9b28cfd0432baf6595297199a340d36d669b5b5f53950866a6"
+      sha256: "44feaa7058191b5d3cd7c9ff195262725773643121bcada172d49c2ddcff71cb"
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.0+1"
+    version: "6.0.0"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
   flutter:
     sdk: flutter
   http: ^0.13.6
-  flutter_appauth: ^5.0.0
+  flutter_appauth: ^6.0.0
   flutter_secure_storage: ^8.0.0
   simple_gravatar: ^1.1.0
 


### PR DESCRIPTION
Closes #5 

Changes:

- :passport_control: Logging out of FusionAuth by using [`endSession`](https://pub.dev/documentation/flutter_appauth/latest/flutter_appauth/FlutterAppAuth/endSession.html) method
- :arrow_up: Upgraded `flutter_appauth` from 5.0 to 6.0
- :rotating_light: Made `MyAppState` public due to [this linting error](https://dart-lang.github.io/linter/lints/library_private_types_in_public_api.html)
- :recycle: Changed constants from `FUSION_AUTH_...` to `FUSIONAUTH_...`
- :wrench: Removed `://login-callback` from the iOS URL scheme to make it more consistent with other tutorials from the Web